### PR TITLE
Add support for custom errors

### DIFF
--- a/README.org
+++ b/README.org
@@ -985,6 +985,43 @@ If we have executed above command we would see the following output.
   foo post-hook has been invoked
 #+end_src
 
+* Custom Errors
+
+The =CLINGON:BASE-ERROR= condition may be used as the base for
+user-defined conditions.
+
+The =CLINGON:RUN= method will invoke =CLINGON:HANDLE-ERROR= for
+conditions which sub-class =CLINGON:BASE-ERROR=. The implementation of
+=CLINGON:HANDLE-ERROR= allows the user to customize the way errors are
+being reported and handled.
+
+The following example creates a new custom condition.
+
+#+begin_src lisp
+  (in-package :cl-user)
+  (defpackage :my.clingon.app
+    (:use :cl)
+    (:import-from :clingon)
+    (:export :my-app-error))
+  (in-package :my.clingon.app)
+
+  (define-condition my-app-error (clingon:base-error)
+    ((message
+      :initarg :message
+      :initform (error "Must specify message")
+      :reader my-app-error-message))
+    (:documentation "My custom app error condition"))
+
+  (defmethod clingon:handle-error ((err my-app-error))
+    (let ((message (my-app-error-message err)))
+      (format *error-output* "Oops, an error occurred: ~A~%" message)))
+#+end_src
+
+You can now use the =MY-APP-ERROR= condition anywhere in your command
+handlers and signal it. When this condition is signalled =clingon=
+will invoke the =CLINGON:HANDLE-ERROR= generic function for your
+condition.
+
 * Options
 
 The =clingon= system supports various kinds of options, each of which

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -59,7 +59,10 @@
    :missing-option-argument
    :missing-option-argument-item
    :missing-option-argument-command
-   :option-derive-error-p)
+   :option-derive-error-p
+   :base-error
+   :exit-error
+   :exit-error-code)
   (:import-from
    :clingon.options
    :option
@@ -96,6 +99,7 @@
    :parse-option
    :initialize-command
    :finalize-command
+   :handle-error
    :command
    :command-name
    :command-options
@@ -133,6 +137,7 @@
    :validate-top-level-command
    :print-usage
    :print-usage-and-exit
+   :print-version
    :print-version-and-exit
    :print-documentation
    :print-options-usage
@@ -147,6 +152,15 @@
    :*default-bash-completions-flag*
    :*default-options*))
 (in-package :clingon.command)
+
+(defgeneric handle-error (condition)
+  (:documentation "Handles the condition. This generic function will be called by
+clingon for conditions which sub-class the CLINGON:BASE-ERROR
+condition. The CLINGON:BASE-ERROR condition is the base class for app
+specific errors."))
+
+(defmethod handle-error ((error exit-error))
+  (exit (exit-error-code error)))
 
 (defgeneric find-option (kind object name)
   (:documentation "Returns the option of the given KIND and NAME, or NIL otherwise"))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -488,10 +488,11 @@ _~~A() {
      ;; If this is a sub-command and we don't have a version string,
      ;; then try to find a version string from some of the parent
      ;; commands.
-     (let ((cmd-with-version (some (lambda (item)
-                                     (and (command-version item) item))
-                                   (command-lineage command))))
-       (print-version cmd-with-version t)
+     (let ((cmd (some (lambda (item)
+                        (and (command-version item) item))
+                      (command-lineage command))))
+       (when cmd
+         (print-version cmd t))
        (error 'exit-error :code 0)))
     ((getopt command :clingon.help.flag)
      (print-usage command t)

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -51,7 +51,10 @@
    :missing-required-option-value-command
    :option-derive-error
    :option-derive-error-reason
-   :option-derive-error-p))
+   :option-derive-error-p
+   :base-error
+   :exit-error
+   :exit-error-code))
 (in-package :clingon.conditions)
 
 (define-condition option-derive-error (simple-error)
@@ -176,3 +179,15 @@
   (:report (lambda (condition stream)
              (format stream "Invalid option: ~A" (invalid-option-reason condition))))
   (:documentation "A condition which is signalled when an option is identified as invalid"))
+
+(define-condition base-error (simple-error)
+  ()
+  (:documentation "A base condition to be used for app specific errors"))
+
+(define-condition exit-error (base-error)
+  ((code
+    :initarg :code
+    :initform (error "Must specify exit code")
+    :reader exit-error-code
+    :documentation "The exit code to be returned to the operating system"))
+  (:documentation "A condition representing an error with associated exit code"))

--- a/src/conditions.lisp
+++ b/src/conditions.lisp
@@ -61,7 +61,7 @@
     :reader option-derive-error-reason
     :documentation "Reason for which deriving a value failed"))
   (:report (lambda (condition stream)
-	     (format stream "~A" (option-derive-error-reason condition))))
+             (format stream "~A" (option-derive-error-reason condition))))
   (:documentation "A condition which is signalled when deriving an option's value has failed"))
 
 (defun option-derive-error-p (value)
@@ -118,13 +118,13 @@
     :initform (error "Must specify duplicate items")
     :reader duplicate-command-items))
   (:report (lambda (condition stream)
-	     (let ((items (duplicate-command-items condition)))
-	       (format stream
-		       "Detected ~A duplicate command names/aliases.~2%~
+             (let ((items (duplicate-command-items condition)))
+               (format stream
+                       "Detected ~A duplicate command names/aliases.~2%~
                        The following commands have been identified as ~
                        providing duplicate names/aliases.~2%~
                        ~A~%"
-		       (length items) items))))
+                       (length items) items))))
    (:documentation "A condition which is signalled when a command provides duplicate sub-commands"))
 
 (define-condition unknown-option (error)
@@ -155,7 +155,7 @@
     :initform (error "Must specify command")
     :reader missing-option-argument-command))
   (:report (lambda (condition stream)
-	     (declare (ignore condition))
+             (declare (ignore condition))
              (format stream "Missing argument for option")))
   (:documentation "A condition which is signalled when an option expects an argument, but none was provided"))
 

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -76,8 +76,9 @@
           (format s "~A" item)))))
 
 (defun exit (&optional (code 0))
-  "Exit the program returning the given status code"
-  (uiop:quit code))
+  "Exit the program returning the given exit code to the operating system"
+  (declare (ignore code))
+  #-(or swank slynk) (uiop:quit code))
 
 (defun git-rev-parse (&key short (rev "HEAD") (path "."))
   "Returns the git revision with the given REV"

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -77,8 +77,11 @@
 
 (defun exit (&optional (code 0))
   "Exit the program returning the given exit code to the operating system"
-  (declare (ignore code))
-  #-(or swank slynk) (uiop:quit code))
+  ;; Do not exit if we are running from SLY or SLIME
+  (unless (some (lambda (feat)
+                  (member feat *features*))
+                (list :slynk :swank))
+    (uiop:quit code)))
 
 (defun git-rev-parse (&key short (rev "HEAD") (path "."))
   "Returns the git revision with the given REV"


### PR DESCRIPTION
- Adds support for defining and handling of custom conditions
- Also, do =CLINGON:EXIT= will not exit if running from Sly or SLIME, allowing for better testing experience from the REPL.