### PR TITLE
A couple of minor fixes

### DIFF
--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1028,7 +1028,7 @@ _~~A() {
 (defmethod print-usage ((command command) stream &key (wrap-at 70))
   (initialize-command command)
   (format stream "NAME:~%")
-  (format stream "  ~A - ~A~2%" (command-full-name command) (command-description command))
+  (format stream "  ~A~@[ - ~A~]~2%" (command-full-name command) (command-description command))
 
   (format stream "USAGE:~%")
   (format stream "  ~A~2%" (command-usage-string command))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -482,7 +482,7 @@ _~~A() {
        (error 'exit-error :code 0)))
     ((getopt command :clingon.help.flag)
      (print-usage command t)
-     (error 'exit-error :code 64))) ;; EX_USAGE
+     (error 'exit-error :code 0)))
 
   ;; Verify required options
   (let ((required-options (remove-if-not #'option-required-p (command-options command))))


### PR DESCRIPTION
- Exit with EX_OK instead of EX_USAGE if clingon.help.flag is set
- Do not print command's short description if it's not set