### PR TITLE
Added man page support to print-documentation

### DIFF
--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1211,9 +1211,7 @@ available at https://man.openbsd.org/mdoc.7"
       ;; [arguments...]"
       )
 
-    ;; FIXME: show command aliases, show option environment variables,
-    ;; show option default values, group options by category, mark if
-    ;; an option is required
+    ;; FIXME: show command aliases, group options by category
     (format stream ".Sh DESCRIPTION~%")
     (with-command-tree (node top-level)
       (initialize-command node)
@@ -1229,11 +1227,22 @@ available at https://man.openbsd.org/mdoc.7"
             :unless (option-hidden-p opt)
               :do (format stream ".It Fl~:[~:; ~:*~A,~]~
                                      ~:[~:; -~:*~A~]~
-                                     ~:[~:; Ar ~:*~A~]~%~
+                                     ~:[~:; Ar ~:*~A~]~
+                                     ~:[~:; Ev (env: ~:*~{~A~^, ~})~]~
+                                     ~:[~:; Dv (default: ~:*~A)~]~
+                                     ~:[~:; Sy REQUIRED ~]~%~
                                 ~{~A~%~}"
                          (option-short-name opt)
                          (option-long-name opt)
-                         (option-parameter opt)
+                         (if (eql (class-of opt)
+                                  (find-class 'clingon.options:option-enum))
+                             (format NIL "(options: ~{~A~^, ~})"
+                                     (loop :for kv :in (clingon.options:option-enum-items opt)
+                                           :collect (car kv)))
+                             (option-parameter opt))
+                         (clingon.options:option-env-vars opt)
+                         (clingon.options:option-initial-value opt)
+                         (option-required-p opt)
                          (wrap-paragraph (option-description opt))))
       (format stream ".El~%"))
 

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1253,21 +1253,31 @@ available at https://man.openbsd.org/mdoc.7"
 
     ;; CONTEXT, IMPLEMENTATION NOTES, RETURN VALUES
 
-    ;; FIXME: show corresponding option (including parent subcommand,
-    ;; if present), default value, and mark if it's required.
     (format stream ".Sh ENVIRONMENT~%")
     (with-command-tree (node top-level)
       (initialize-command node)
       (let ((vars (loop :for opt :in (command-options node)
-                        :for desc = (wrap-paragraph (option-description opt))
-                        :for env  = (clingon.options:option-env-vars opt)
-                        :when env :collect (cons env desc))))
+                        :when (clingon.options:option-env-vars opt)
+                          :collect opt)))
         (when vars
           (unless (eq node top-level)
             (format stream ".Ss ~A~%" (command-full-name node)))
           (format stream ".Bl -tag -width DS~%")
-          (loop :for (env . desc) :in vars
-                :do (format stream ".It ~{Ev ~A~^, ~}~%~{~A~%~}" env desc))
+          (loop :for opt :in vars
+                :do (format stream ".It ~{Ev ~A~^, ~} ~
+                                        Fl~:[~:; ~:*~A,~]~
+                                          ~:[~:; -~:*~A~]~
+                                          ~:[~:; Ar ~:*~A~]~
+                                        ~:[~:; Dv (default: ~:*~A)~]~
+                                        ~:[~:; Sy REQUIRED ~]~%~
+                                    ~{~A~%~}"
+                            (clingon.options:option-env-vars opt)
+                            (option-short-name opt)
+                            (option-long-name opt)
+                            (option-parameter opt)
+                            (clingon.options:option-initial-value opt)
+                            (option-required-p opt)
+                            (wrap-paragraph (option-description opt))))
           (format stream ".El~%"))))
 
     ;; FILES, EXIST STATUS

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1211,12 +1211,17 @@ available at https://man.openbsd.org/mdoc.7"
       ;; [arguments...]"
       )
 
-    ;; FIXME: show command aliases, group options by category
+    ;; FIXME: group options by category
     (format stream ".Sh DESCRIPTION~%")
     (with-command-tree (node top-level)
       (initialize-command node)
       (unless (eq node top-level)
-        (format stream ".Ss ~A~%" (command-full-name node)))
+        (format stream ".Ss ~A~[~:; ~
+                                   (alias~:*~[es~;~:;es~]: ~
+                                    ~{~(~A~)~^, ~})~]~%"
+                (command-full-name node)
+                (length (command-aliases node))
+                (command-aliases node)))
       (let* ((desc (if (command-long-description node)
                        (command-long-description node)
                        (command-description node))))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1180,13 +1180,17 @@ available at https://man.openbsd.org/mdoc.7"
   ;; FIXME: scan through text and attempt to coerce links and stuff
   ;; into mdoc?
   (labels ((wrap-paragraph (par)
-             (split-sequence #\Newline (bobbin:wrap par wrap-at))))
-    (format stream ".Dd today~%~
+             (split-sequence #\Newline (bobbin:wrap par wrap-at)))
+           (timestamp ()
+             (let ((now (multiple-value-list (decode-universal-time (get-universal-time)))))
+               (format NIL "~A-~A-~A" (nth 5 now) (nth 4 now) (nth 3 now)))))
+    (format stream ".Dd ~A~%~
                   .Dt ~:@(~A~) 1~%~
                   .Os~%~
                   .Sh NAME~%~
                   .Nm ~:*~A~%~
                   .Nd ~A~%"
+            (timestamp)
             (command-full-name top-level)
             (command-description top-level))
 

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1206,10 +1206,14 @@ available at https://man.openbsd.org/mdoc.7"
                           (option-short-name opt)
                           (option-long-name opt)
                           (option-parameter opt)))
-      ;; FIXME: Figure out a way to detect if a command takes
-      ;; positional arguments and print something like ".Op Ar
-      ;; [arguments...]"
-      )
+      ;; FIXME: As it stands there is not really any good way to
+      ;; display the command's arguments; the closest thing is
+      ;; `command-usage' with the huge downside that clingon wants you
+      ;; to specify arguments in there too, which clashes really badly
+      ;; with the rest of the synopsis.  Need to ask advice on how
+      ;; best to approach this.
+      (when (command-usage node)
+        (format stream ".Op Ar ~A~%" (command-usage node))))
 
     ;; FIXME: It would be good to group options by category, but I'm
     ;; not sure how to do it without inserting subsections at the same

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1057,7 +1057,7 @@ _~~A() {
         (dolist (line lines)
           (format stream "  ~A~%" line))
         (format stream "~%")
-        (dolist (line (split-sequence #\Newline *s*))
+        (dolist (line (split-sequence #\Newline code))
           (format T "    ~A~%" line))
         (format stream "~%"))))
 

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1057,7 +1057,8 @@ _~~A() {
         (dolist (line lines)
           (format stream "  ~A~%" line))
         (format stream "~%")
-        (format stream "    ~A~%" code)
+        (dolist (line (split-sequence #\Newline *s*))
+          (format T "    ~A~%" line))
         (format stream "~%"))))
 
   (when (command-authors command)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1295,8 +1295,8 @@ available at https://man.openbsd.org/mdoc.7"
         (format stream ".Ss ~A~%" (command-full-name node)))
       (loop :for (desc . code) :in (command-examples node)
             :do (format stream ".Pp~%~{~A~%~}" (wrap-paragraph desc))
-                (format stream ".Bd -literal~%")
-                (format stream "~A" code)
+                (format stream ".Bd -literal -offset indent~%")
+                (format stream "~A~%" code)
                 (format stream ".Ed~%")))
 
     (format stream ".Sh AUTHORS~%~{.An ~A~%~}" (command-authors top-level))))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1222,12 +1222,16 @@ available at https://man.openbsd.org/mdoc.7"
     (with-command-tree (node top-level)
       (initialize-command node)
       (unless (eq node top-level)
-        (format stream ".Ss ~A~[~:; ~
-                                   (alias~:*~[es~;~:;es~]: ~
-                                    ~{~(~A~)~^, ~})~]~%"
+        (format stream ".Ss ~A~A~A~%"
                 (command-full-name node)
-                (length (command-aliases node))
-                (command-aliases node)))
+                (if (command-aliases node)
+                    (format NIL " (alias~:*~[es~;~:;es~]: ~{~(~A~)~^, ~})"
+                            (length (command-aliases node))
+                            (command-aliases node))
+                    "")
+                (if (command-usage node)
+                    (format NIL " ~A" (command-usage node))
+                    "")))
       (let* ((desc (if (command-long-description node)
                        (command-long-description node)
                        (command-description node))))

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -1174,11 +1174,11 @@ _~~A() {
 (defmethod print-documentation ((kind (eql :mandoc)) (top-level command) stream &key (wrap-at 80))
   "Generates section 1 man pages in the mdoc(7) format.  Documentation
 available at https://man.openbsd.org/mdoc.7"
-  ;; FIXME: were do license and version information go?
-  ;; FIXME: consider looking at package and asd system documentation
-  ;; for further information.
-  ;; FIXME: scan through text and attempt to coerce links and stuff
-  ;; into mdoc?
+  ;; FIXME: Other man sections are "context, implementation notes,
+  ;; return values, files, exit status, diagnostics, errors, see also,
+  ;; standards, history, caveats, bugs, and security considerations";
+  ;; not sure how we'd go about generating them, but it would be good
+  ;; to do so.
   (labels ((wrap-paragraph (par)
              (split-sequence #\Newline (bobbin:wrap par wrap-at)))
            (timestamp ()
@@ -1211,7 +1211,9 @@ available at https://man.openbsd.org/mdoc.7"
       ;; [arguments...]"
       )
 
-    ;; FIXME: group options by category
+    ;; FIXME: It would be good to group options by category, but I'm
+    ;; not sure how to do it without inserting subsections at the same
+    ;; level as subcommand names, which isn't ideal
     (format stream ".Sh DESCRIPTION~%")
     (with-command-tree (node top-level)
       (initialize-command node)
@@ -1251,8 +1253,6 @@ available at https://man.openbsd.org/mdoc.7"
                          (wrap-paragraph (option-description opt))))
       (format stream ".El~%"))
 
-    ;; CONTEXT, IMPLEMENTATION NOTES, RETURN VALUES
-
     (format stream ".Sh ENVIRONMENT~%")
     (with-command-tree (node top-level)
       (initialize-command node)
@@ -1280,8 +1280,6 @@ available at https://man.openbsd.org/mdoc.7"
                             (wrap-paragraph (option-description opt))))
           (format stream ".El~%"))))
 
-    ;; FILES, EXIST STATUS
-
     (format stream ".Sh EXAMPLES~%")
     (with-command-tree (node top-level)
       (initialize-command node)
@@ -1293,10 +1291,7 @@ available at https://man.openbsd.org/mdoc.7"
                 (format stream "~A" code)
                 (format stream ".Ed~%")))
 
-    ;; DIAGNOSTICS, ERRORS, SEE ALSO, STANDARDS, HISTORY
-    (format stream ".Sh AUTHORS~%~{.An ~A~%~}" (command-authors top-level))
-    ;; CAVEATS, BUGS, SECURITY CONSIDERATIONS
-    ))
+    (format stream ".Sh AUTHORS~%~{.An ~A~%~}" (command-authors top-level))))
 
 (defmethod zsh-sub-command-items ((command command))
   "Returns the sub-command items, which will be populated in the Zsh completion function"


### PR DESCRIPTION
I added a specialization of `command`'s `print-documentation` method which produces documentation in the [mdoc](http://man.openbsd.org/mdoc.7) format for man pages.  It seems to work well for the programs in the examples directory, as well as [Leibowitz](https://github.com/halcyonseeker/leibowitz), a subcommand-heavy program I've been developing.  For reference, the man page generated by this method is attached [here](https://github.com/user-attachments/files/15523690/leibowitz.1.txt).

This new method works pretty well so far, but there are two limitations I'm not sure how to resolve:

### Firstly

Mdoc is designed to represent parts of a man page semantically, with command-line flags and arguments in the SYNOPSIS section typeset with the `.Op` macro.  This is fine for flags, but clingon doesn't seem to expose a way to find the free arguments a command makes usage of.  The closest I found was the `command-usage` slot, which, in the example programs, also contains flags.  This results in SYNOPSIS lines containing redundant information like this one for intro:

```
SYNOPSIS
       clingon‐intro [-‐version] [-‐help] [-v, -‐verbose] [-u, -‐user VALUE] [[‐v] [‐u <USER>]]
       clingon‐intro shout [-‐version] [-‐help] [[options] [arguments ...]]
```

In Leibowitz I resolved this by [not writing the flags in the `command-usage` slot](https://github.com/halcyonseeker/leibowitz/blob/c5e59fb8fda6cf94ec93e7655e7cabcf7c8f2881/cli/main.lisp#L746), but judging from clingon's examples and documentation this doesn't seem to be the way it's intended to be used.

What do you think would be the best approach here?

### Secondly

Man pages conventionally have quite a few sections (the previously linked mdoc(7) also lists context, implementation notes, return values, files, exit status, diagnostics, errors, see also, standards, history, caveats, bugs, and security considerations) which don't correspond directly to slots of the `command` class.  Some of these are really important, do you think it would make sense to add slots to `command` specifically to generate these?
